### PR TITLE
APM-00 add _ping and _status endpoints to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ dist/
 build/
 public/
 newman/
-
+.idea
+.DS_Store
 .#*
 
 __pycache__/

--- a/proxies/live/apiproxy/policies/AssignMessage.AddPayloadToPing.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddPayloadToPing.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage continueOnError="false" enabled="true" name="AssignMessage.AddPayloadToPing" async="false">
+  <Set>
+    <Payload>{"version":"{{ DEPLOYED_VERSION }}","revision":"{apiproxy.revision}","releaseId":"{{ RELEASE_RELEASEID }}","commitId":"{{ SOURCE_COMMIT_ID }}"}</Payload>
+    <StatusCode>200</StatusCode>
+    <Verb>GET</Verb>
+    <Version>1.1</Version>
+  </Set>
+  <AssignTo createNew="false" transport="http" type="request"/>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.RenameQuotaVarsFromVerifyAPIKeyPolicyClientId.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.RenameQuotaVarsFromVerifyAPIKeyPolicyClientId.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage name="AssignMessage.RenameQuotaVarsFromVerifyAPIKeyPolicyClientId">
+  <AssignVariable>
+    <Name>apiproduct.developer.quota.limit</Name>
+    <Ref>verifyapikey.VerifyApiKey.XApiKey.apiproduct.developer.quota.limit</Ref>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>apiproduct.developer.quota.interval</Name>
+    <Ref>verifyapikey.VerifyApiKey.XApiKey.apiproduct.developer.quota.interval</Ref>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>apiproduct.developer.quota.timeunit</Name>
+    <Ref>verifyapikey.VerifyApiKey.XApiKey.apiproduct.developer.quota.timeunit</Ref>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>apiproduct.ratelimit</Name>
+    <Ref>verifyapikey.VerifyApiKey.XApiKey.apiproduct.ratelimit</Ref>
+  </AssignVariable>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/VerifyApiKey.XApiKey.xml
+++ b/proxies/live/apiproxy/policies/VerifyApiKey.XApiKey.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<VerifyAPIKey async="false" continueOnError="false" enabled="true" name="VerifyApiKey.XApiKey">
+    <APIKey ref="request.header.x-api-key"/>
+</VerifyAPIKey>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -18,6 +18,9 @@
     <RouteRule name="NoRoute">
         <Condition>request.verb == "OPTIONS" AND request.header.origin != null AND request.header.Access-Control-Request-Method != null</Condition>
     </RouteRule>
+    <RouteRule name="NoRoutePing">
+      <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
+    </RouteRule>
     <RouteRule name="{{ config.meta.canonical_name }}-target">
         <TargetEndpoint>{{ config.meta.canonical_name }}-target</TargetEndpoint>
     </RouteRule>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -19,17 +19,6 @@
         </Response>
         <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
       </Flow>
-      <Flow name="Flow.AuthApiKey">
-        <Request>
-          <Step>
-            <Name>VerifyApiKey.XApiKey</Name>
-          </Step>
-        </Request>
-        <Response/>
-        <!-- This will return 404 because /_status doesn't exist for the backend. Either implement _status for your backend
-        or use a service-callout to call health-check endpoint -->
-        <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
-      </Flow>
     </Flows>
     <PreFlow/>
     <HTTPProxyConnection>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -9,6 +9,25 @@
             </Response>
         <Condition>request.verb == "OPTIONS" AND request.header.origin != null AND request.header.Access-Control-Request-Method != null</Condition>
       </Flow>
+      <Flow name="AddPayloadToPing">
+        <Description/>
+        <Request/>
+        <Response>
+          <Step>
+            <Name>AssignMessage.AddPayloadToPing</Name>
+          </Step>
+        </Response>
+        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "GET"))</Condition>
+      </Flow>
+      <Flow name="Flow.AuthApiKey">
+        <Request>
+          <Step>
+            <Name>VerifyApiKey.XApiKey</Name>
+          </Step>
+        </Request>
+        <Response/>
+        <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
+      </Flow>
     </Flows>
     <PreFlow/>
     <HTTPProxyConnection>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -17,7 +17,7 @@
             <Name>AssignMessage.AddPayloadToPing</Name>
           </Step>
         </Response>
-        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "GET"))</Condition>
+        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
       </Flow>
       <Flow name="Flow.AuthApiKey">
         <Request>
@@ -26,6 +26,8 @@
           </Step>
         </Request>
         <Response/>
+        <!-- This will return 404 because /_status doesn't exist for the backend. Either implement _status for your backend
+        or use a service-callout to call health-check endpoint -->
         <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
       </Flow>
     </Flows>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -12,6 +12,12 @@
   </FaultRules>
   <PreFlow>
     <Request>
+        <Step>
+          <!-- This will return 404 because /_status doesn't exist for the backend. Either implement _status for your backend
+          or use a service-callout to call health-check endpoint -->
+          <Name>VerifyApiKey.XApiKey</Name>
+          <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
+        </Step>
       <Step>
         <Name>Quota</Name>
       </Step>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -12,12 +12,15 @@
   </FaultRules>
   <PreFlow>
     <Request>
-        <Step>
-          <!-- This will return 404 because /_status doesn't exist for the backend. Either implement _status for your backend
-          or use a service-callout to call health-check endpoint -->
-          <Name>VerifyApiKey.XApiKey</Name>
-          <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
-        </Step>
+      <Step>
+        <!-- This will return 404 because /_status doesn't exist for the backend. Either implement _status for your backend
+        or use a service-callout to call health-check endpoint -->
+        <Name>VerifyApiKey.XApiKey</Name>
+        <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
+      </Step>
+      <Step>
+        <Name>AssignMessage.RenameQuotaVarsFromVerifyAPIKeyPolicyClientId</Name>
+      </Step>
       <Step>
         <Name>Quota</Name>
       </Step>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -13,30 +13,10 @@
   <PreFlow>
     <Request>
       <Step>
-        <!-- Header NHSD-Session-URID must be present and not empty -->
-        <Name>RaiseFault.400BadRequest</Name>
-        <Condition>(request.header.NHSD-Session-URID is null) or (not request.header.NHSD-Session-URID ~~ ".+")</Condition>
-      </Step>
-      <Step>
-        <Name>OauthV2.VerifyAccessToken</Name>
-      </Step>
-      <Step>
         <Name>Quota</Name>
       </Step>
       <Step>
         <Name>SpikeArrest</Name>
-      </Step>
-      <Step>
-        <Name>AssignMessage.AddUserIdHeader</Name>
-      </Step>
-      <Step>
-        <Name>AssignMessage.AddIssuerHeader</Name>
-      </Step>
-      <Step>
-        <Name>KeyValueMapOperations.GetSecureVariables</Name>
-      </Step>
-      <Step>
-        <Name>AssignMessage.AddAsidHeader</Name>
       </Step>
     </Request>
   </PreFlow>

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.AddPayloadToPing.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.AddPayloadToPing.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage continueOnError="false" enabled="true" name="AssignMessage.AddPayloadToPing" async="false">
+  <Set>
+    <Payload>{"version":"{{ DEPLOYED_VERSION }}","revision":"{apiproxy.revision}","releaseId":"{{ RELEASE_RELEASEID }}","commitId":"{{ SOURCE_COMMIT_ID }}"}</Payload>
+    <StatusCode>200</StatusCode>
+    <Verb>GET</Verb>
+    <Version>1.1</Version>
+  </Set>
+  <AssignTo createNew="false" transport="http" type="request"/>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/proxies/sandbox/apiproxy/policies/VerifyApiKey.XApiKey.xml
+++ b/proxies/sandbox/apiproxy/policies/VerifyApiKey.XApiKey.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<VerifyAPIKey async="false" continueOnError="false" enabled="true" name="VerifyApiKey.XApiKey">
+    <APIKey ref="request.header.x-api-key"/>
+</VerifyAPIKey>

--- a/proxies/sandbox/apiproxy/proxies/default.xml
+++ b/proxies/sandbox/apiproxy/proxies/default.xml
@@ -9,12 +9,34 @@
             </Response>
         <Condition>request.verb == "OPTIONS" AND request.header.origin != null AND request.header.Access-Control-Request-Method != null</Condition>
       </Flow>
+      <Flow name="AddPayloadToPing">
+        <Description/>
+        <Request/>
+        <Response>
+          <Step>
+            <Name>AssignMessage.AddPayloadToPing</Name>
+          </Step>
+        </Response>
+        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "GET"))</Condition>
+      </Flow>
+      <Flow name="Flow.AuthApiKey">
+        <Request>
+          <Step>
+            <Name>VerifyApiKey.XApiKey</Name>
+          </Step>
+        </Request>
+        <Response/>
+        <Condition>(proxy.pathsuffix MatchesPath "/_status") and (request.verb = "GET")</Condition>
+      </Flow>
     </Flows>
     <PreFlow/>
     <HTTPProxyConnection>
         <BasePath>{{ SERVICE_BASE_PATH }}</BasePath>
         <VirtualHost>secure</VirtualHost>
     </HTTPProxyConnection>
+    <RouteRule name="NoRoutePing">
+      <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
+    </RouteRule>
     <RouteRule name="NoRoute">
         <Condition>request.verb == "OPTIONS" AND request.header.origin != null AND request.header.Access-Control-Request-Method != null</Condition>
     </RouteRule>

--- a/proxies/sandbox/apiproxy/proxies/default.xml
+++ b/proxies/sandbox/apiproxy/proxies/default.xml
@@ -17,7 +17,7 @@
             <Name>AssignMessage.AddPayloadToPing</Name>
           </Step>
         </Response>
-        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "GET"))</Condition>
+        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
       </Flow>
       <Flow name="Flow.AuthApiKey">
         <Request>

--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -1,18 +1,7 @@
 <TargetEndpoint name="sandbox">
     <Description/>
     <FaultRules/>
-    <Flows>
-      <Flow name="AddStatusToPing">
-        <Description/>
-        <Request/>
-        <Response>
-          <Step>
-            <Name>AssignMessage.AddStatusToPing</Name>
-          </Step>
-        </Response>
-        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "GET"))</Condition>
-      </Flow>
-    </Flows>
+    <Flows/>
     <PostFlow name="PostFlow">
         <Request/>
         <Response/>
@@ -25,9 +14,6 @@
           </Step>
         </Response>
     </PreFlow>
-  <RouteRule name="NoRoutePing">
-    <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
-  </RouteRule>
   <HostedTarget>
         <Properties/>
     </HostedTarget>

--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -1,7 +1,18 @@
 <TargetEndpoint name="sandbox">
     <Description/>
     <FaultRules/>
-    <Flows/>
+    <Flows>
+      <Flow name="AddStatusToPing">
+        <Description/>
+        <Request/>
+        <Response>
+          <Step>
+            <Name>AssignMessage.AddStatusToPing</Name>
+          </Step>
+        </Response>
+        <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "GET"))</Condition>
+      </Flow>
+    </Flows>
     <PostFlow name="PostFlow">
         <Request/>
         <Response/>
@@ -14,7 +25,10 @@
           </Step>
         </Response>
     </PreFlow>
-    <HostedTarget>
+  <RouteRule name="NoRoutePing">
+    <Condition>(proxy.pathsuffix MatchesPath "/_ping") and ((request.verb = "GET") or (request.verb = "HEAD"))</Condition>
+  </RouteRule>
+  <HostedTarget>
         <Properties/>
     </HostedTarget>
 </TargetEndpoint>


### PR DESCRIPTION
## Summary
This PR adds `/_ping` and `_status` to the template. [here](https://github.com/NHSDigital/template-example-api) is the demo project that I created based of these changes. `_ping` works but the version field is empty and that's due to demo project configuration. `_status` returns 404 because `backend/_status` doesn't exists and this is intentional. During Monitoring Show&Tell we decided to do this so, the user of the template knows that this needs to be changed accordingly.

I've deleted all the User Restricted steps because this template was assuming that the proxy is user restricted and I had to add condition for _status in all those steps. The other reason for this is that we have Hello World as implementation reference. . If there is no objections to this I **still need to delete unused policies**, otherwise I think the best place to hook those steps (Auth) is inside proxy definition and not target. 